### PR TITLE
Add missing os import

### DIFF
--- a/rofi-sound-picker
+++ b/rofi-sound-picker
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import io
+import os
 import json
 import shlex
 import subprocess


### PR DESCRIPTION
Thanks for the scrip. Just tried out, and it complained for missing os module, because it wasn't imported. Adding it back here.